### PR TITLE
fix(render): differentiate between Phaser `GameObject` and `FunctionComponent`

### DIFF
--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -1,9 +1,12 @@
 import Phaser from 'phaser';
 import type { JSX } from 'react';
 
+import * as GameObjects from '../components/GameObjects';
 import { isValidElement } from '../element';
 import { setProps } from './props';
 import { attachRef } from './ref';
+
+const gameObjects = Object.values(GameObjects);
 
 /**
  * Creates Phaser game object and adds it to the container.
@@ -29,17 +32,11 @@ export function createGameObject(element: JSX.Element, scene: Phaser.Scene) {
 
   let gameObject: Phaser.GameObjects.GameObject;
 
-  switch (element.type) {
-    case Phaser.GameObjects.Text:
-      gameObject = new element.type(scene, props.x, props.y, text, style);
-      break;
-
-    default:
-      gameObject = new element.type(scene);
-      break;
-  }
-
-  if (!(gameObject instanceof Phaser.GameObjects.GameObject)) {
+  if (element.type === Phaser.GameObjects.Text) {
+    gameObject = new element.type(scene, props.x, props.y, text, style);
+  } else if (gameObjects.includes(element.type)) {
+    gameObject = new element.type(scene);
+  } else {
     return createGameObject(new element.type(element.props), scene);
   }
 

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -34,7 +34,7 @@ export function createGameObject(element: JSX.Element, scene: Phaser.Scene) {
 
   if (element.type === Phaser.GameObjects.Text) {
     gameObject = new element.type(scene, props.x, props.y, text, style);
-  } else if (gameObjects.includes(element.type)) {
+  } else if (gameObjects.indexOf(element.type) > -1) {
     gameObject = new element.type(scene);
   } else {
     return createGameObject(new element.type(element.props), scene);


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): differentiate between Phaser GameObject and FunctionComponent

## What is the current behavior?

`render` will try to create a game object regardless if it's a Phaser `GameObject` or React `FunctionComponent`, which will cause an error since the `scene` is not passed for the latter

## What is the new behavior?

Check if `element.type` is a Phaser `GameObject` or `FunctionComponent` before instantiating

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation