### PR TITLE
feat(hooks): pass optional type generic to useScene

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ const scene = useScene();
 > [!WARNING]
 > Don't use this hook if you start multiple Scenes.
 
+To specify a Scene class in TypeScript:
+
+```ts
+class MyScene extends Phaser.Scene {}
+
+const scene = useScene<typeof MyScene>();
+```
+
 ## Release
 
 Release is automated with [Release Please](https://github.com/googleapis/release-please).

--- a/src/helpers/scene.test.ts
+++ b/src/helpers/scene.test.ts
@@ -8,8 +8,15 @@ afterEach(() => {
   setScene(undefined as unknown as Scene);
 });
 
-it('sets and gets scene', () => {
-  expect(getScene()).toEqual(undefined);
-  expect(setScene(scene)).toEqual(undefined);
-  expect(getScene()).toEqual(scene);
+describe('getScene', () => {
+  it('gets scene', () => {
+    expect(getScene<typeof scene>()).toEqual(undefined);
+  });
+});
+
+describe('setScene', () => {
+  it('sets scene', () => {
+    expect(setScene(scene)).toEqual(undefined);
+    expect(getScene()).toEqual(scene);
+  });
 });

--- a/src/helpers/scene.ts
+++ b/src/helpers/scene.ts
@@ -2,8 +2,8 @@ import type { Scene } from 'phaser';
 
 let _scene: Scene;
 
-export function getScene() {
-  return _scene;
+export function getScene<Type = Scene>() {
+  return _scene as Type;
 }
 
 export function setScene(scene: Scene) {

--- a/src/hooks/useScene.test.ts
+++ b/src/hooks/useScene.test.ts
@@ -15,3 +15,7 @@ it('returns scene', () => {
   expect(useScene()).toEqual(scene);
   expect(mockedGetScene).toHaveBeenCalledTimes(1);
 });
+
+it('returns undefined', () => {
+  expect(useScene<undefined>()).toEqual(undefined);
+});

--- a/src/hooks/useScene.ts
+++ b/src/hooks/useScene.ts
@@ -1,3 +1,5 @@
+import type { Scene } from 'phaser';
+
 import { getScene } from '../helpers';
 
 /**
@@ -7,6 +9,6 @@ import { getScene } from '../helpers';
  *
  * @returns Phaser.Scene
  */
-export function useScene() {
-  return getScene();
+export function useScene<Type = Scene>() {
+  return getScene<Type>();
 }

--- a/src/types/utils.ts
+++ b/src/types/utils.ts
@@ -1,3 +1,3 @@
-export type RecursivePartial<T> = {
-  [P in keyof T]?: RecursivePartial<T[P]>;
+export type RecursivePartial<Type> = {
+  [Property in keyof Type]?: RecursivePartial<Type[Property]>;
 };


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(hooks): pass optional type generic to useScene

## What is the current behavior?

Cannot override return type of `useScene` hook

## What is the new behavior?

Pass type to `useScene` hook

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation