### PR TITLE
fix(render): instantiate Rectangle in gameobject

### DIFF
--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
 import type { JSX } from 'react';
 
-import { Container, GameObject, Text } from '..';
+import { Container, GameObject, Rectangle, Text } from '..';
 import { createGameObject, setProps } from '.';
 
 jest.mock('phaser', () => {
@@ -9,6 +9,7 @@ jest.mock('phaser', () => {
   class Container extends GameObject {
     add = jest.fn();
   }
+  class Rectangle extends GameObject {}
   class Text extends GameObject {}
 
   return {
@@ -16,6 +17,7 @@ jest.mock('phaser', () => {
       Container,
       GameObject,
       Particles: {},
+      Rectangle,
       Text,
     },
 
@@ -53,8 +55,8 @@ describe('invalid element', () => {
   });
 });
 
-it('creates game object from element', () => {
-  expect(createGameObject(<Text />, scene)).toBeInstanceOf(GameObject);
+it.each([Rectangle, Text])('creates game object from %p', (Component) => {
+  expect(createGameObject(<Component />, scene)).toBeInstanceOf(GameObject);
 });
 
 it('creates game object from component', () => {

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -37,6 +37,18 @@ export function createGameObject(element: JSX.Element, scene: Phaser.Scene) {
       gameObject = new element.type(scene, props.x, props.y, text, style);
       break;
 
+    case element.type === Phaser.GameObjects.Rectangle:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        props.width,
+        props.height,
+        props.fillColor,
+        props.fillAlpha,
+      );
+      break;
+
     case gameObjects.indexOf(element.type) > -1:
       gameObject = new element.type(scene);
       break;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): instantiate Rectangle in gameobject

https://newdocs.phaser.io/docs/3.80.0/focus/Phaser.GameObjects.GameObjectFactory-rectangle

This sets `fillColor` properly otherwise you need to explicitly set `isFilled` to true.

## What is the current behavior?

Rectangle sets `fillColor` on the instance instead of instantiating it

## What is the new behavior?

Rectangle instantiates with `fillColor` is passed via props

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation