### PR TITLE
feat(render): set props `originX` and `originY`

### DIFF
--- a/src/render/props.test.ts
+++ b/src/render/props.test.ts
@@ -6,6 +6,14 @@ jest.mock('phaser', () => ({
   GameObjects: {
     Container: jest.fn(),
     GameObject: jest.fn(),
+    Sprite: jest.fn(() => ({
+      originX: undefined as number | undefined,
+      originY: undefined as number | undefined,
+      setOrigin(originX?: number, originY?: number) {
+        this.originX = originX;
+        this.originY = originY;
+      },
+    })),
     Text: jest.fn(),
   },
   Scene: jest.fn(),
@@ -57,5 +65,19 @@ it('sets prop width and height', () => {
   gameObject.height = 0;
   expect(setProps(gameObject, props, scene)).toBe(undefined);
 
+  expect(gameObject).toMatchObject(props);
+});
+
+it.each([
+  { originX: 0, originY: 0 },
+  { originX: 1, originY: 1 },
+  { originX: 0, originY: 1 },
+  { originX: 1, originY: 0 },
+  { originX: undefined, originY: 0 },
+  { originX: 0, originY: undefined },
+  { originX: undefined, originY: undefined },
+])('sets prop %p', (props) => {
+  const gameObject = new Phaser.GameObjects.Sprite(scene, 0, 0, 'texture');
+  expect(setProps(gameObject, props, scene)).toBe(undefined);
   expect(gameObject).toMatchObject(props);
 });

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -29,4 +29,14 @@ export function setProps(
       continue;
     }
   }
+
+  if (
+    (typeof props.originX === 'number' || typeof props.originY === 'number') &&
+    typeof (gameObject as Phaser.GameObjects.Sprite).setOrigin === 'function'
+  ) {
+    (gameObject as Phaser.GameObjects.Sprite).setOrigin(
+      props.originX as number | undefined,
+      props.originY as number | undefined,
+    );
+  }
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(render): set props `originX` and `originY`

## What is the current behavior?

Origin needs to be set via gameobject `setOrigin()`

## What is the new behavior?

Origin can be set via props

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation