### PR TITLE
feat(render): pass `props.input` to gameObject `setInteractive`

### DIFF
--- a/src/render/props.test.ts
+++ b/src/render/props.test.ts
@@ -34,24 +34,47 @@ it('does not set invalid props', () => {
   expect(JSON.stringify(gameObject)).toBe('{}');
 });
 
-it('sets prop onPointerDown', () => {
-  const gameObject = new Phaser.GameObjects.Container(scene);
-  const props = {
-    onPointerDown: () => {},
-  };
+describe('input', () => {
+  it('sets prop onPointerDown', () => {
+    const gameObject = new Phaser.GameObjects.Container(scene);
+    const props = {
+      onPointerDown: jest.fn(),
+    };
 
-  gameObject.setInteractive = jest.fn();
-  gameObject.on = jest.fn();
-  expect(setProps(gameObject, props, scene)).toBe(undefined);
+    gameObject.setInteractive = jest.fn();
+    gameObject.on = jest.fn();
+    expect(setProps(gameObject, props, scene)).toBe(undefined);
 
-  expect(gameObject.setInteractive).toHaveBeenCalledTimes(1);
-  expect(gameObject.setInteractive).toHaveBeenCalledWith();
-  expect(gameObject.on).toHaveBeenCalledTimes(1);
-  expect(gameObject.on).toHaveBeenCalledWith(
-    'pointerdown',
-    props.onPointerDown,
-    scene,
-  );
+    expect(gameObject.setInteractive).toHaveBeenCalledTimes(1);
+    expect(gameObject.setInteractive).toHaveBeenCalledWith(undefined);
+    expect(gameObject.on).toHaveBeenCalledTimes(1);
+    expect(gameObject.on).toHaveBeenCalledWith(
+      'pointerdown',
+      props.onPointerDown,
+      scene,
+    );
+  });
+
+  it('sets props onPointerOver and input', () => {
+    const gameObject = new Phaser.GameObjects.Container(scene);
+    const props = {
+      onPointerOver: jest.fn(),
+      input: { cursor: 'pointer' },
+    };
+
+    gameObject.setInteractive = jest.fn();
+    gameObject.on = jest.fn();
+    expect(setProps(gameObject, props, scene)).toBe(undefined);
+
+    expect(gameObject.setInteractive).toHaveBeenCalledTimes(1);
+    expect(gameObject.setInteractive).toHaveBeenCalledWith(props.input);
+    expect(gameObject.on).toHaveBeenCalledTimes(1);
+    expect(gameObject.on).toHaveBeenCalledWith(
+      'pointerover',
+      props.onPointerOver,
+      scene,
+    );
+  });
 });
 
 it('sets prop width and height', () => {

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -19,7 +19,7 @@ export function setProps(
     const value = props[key];
 
     if (events[key] && typeof value === 'function') {
-      gameObject.setInteractive();
+      gameObject.setInteractive(props.input);
       gameObject.on(key.slice(2).toLowerCase(), value, scene);
       continue;
     }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(render): pass `props.input` to gameObject `setInteractive`

## What is the current behavior?

Nothing passed to `setInteractive`

## What is the new behavior?

`props.input` passed to `setInteractive`

This allows cursor to be set: https://rexrainbow.github.io/phaser3-rex-notes/docs/site/cursor/

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation