### PR TITLE
fix(render): don't set `input` prop

### DIFF
--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -16,6 +16,10 @@ export function setProps(
   scene: Phaser.Scene,
 ) {
   for (const key in props) {
+    if (key === 'input') {
+      continue;
+    }
+
     const value = props[key];
 
     if (events[key] && typeof value === 'function') {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): don't set `input` prop

## What is the current behavior?

`input` prop is set on gameobject, which breaks `setInteractive`

## What is the new behavior?

`input` prop is not set on gameobject

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation