### PR TITLE
feat(render): set data if prop exists

### DIFF
--- a/src/render/props.test.ts
+++ b/src/render/props.test.ts
@@ -43,6 +43,24 @@ describe('skip prop keys', () => {
   });
 });
 
+describe('data', () => {
+  it('sets prop data', () => {
+    const gameObject = new Phaser.GameObjects.Container(scene);
+    const props = {
+      data: {
+        foo: 'bar',
+        baz: false,
+      },
+    };
+
+    gameObject.setData = jest.fn();
+    expect(setProps(gameObject, props, scene)).toBe(undefined);
+
+    expect(gameObject.setData).toHaveBeenCalledTimes(1);
+    expect(gameObject.setData).toHaveBeenCalledWith(props.data);
+  });
+});
+
 describe('input', () => {
   it('sets prop onPointerDown', () => {
     const gameObject = new Phaser.GameObjects.Container(scene);

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -24,6 +24,11 @@ export function setProps(
 
     const value = props[key];
 
+    if (value && key === 'data') {
+      gameObject.setData(value);
+      continue;
+    }
+
     if (events[key] && typeof value === 'function') {
       gameObject.setInteractive(props.input);
       gameObject.on(key.slice(2).toLowerCase(), value, scene);


### PR DESCRIPTION
## What is the motivation for this pull request?

feat(render): set data if prop exists

https://newdocs.phaser.io/docs/3.80.0/focus/Phaser.GameObjects.TileSprite-setData

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation