### PR TITLE
fix(gameobject): update Sprite props texture and frame

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -637,7 +637,10 @@ export const Shape = GameObjects.Shape as unknown as FC<
  * The main difference between a Sprite and an Image Game Object is that you cannot animate Images. As such, Sprites take a fraction longer to process and have a larger API footprint due to the Animation Component. If you do not require animation then you can safely use Images to replace Sprites in all cases.
  */
 export const Sprite = GameObjects.Sprite as unknown as FC<
-  Props<GameObjects.Sprite>
+  Props<Omit<GameObjects.Sprite, 'texture' | 'frame'>> & {
+    texture: string | Phaser.Textures.Texture;
+    frame?: string | number;
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
 import type { JSX } from 'react';
 
-import { Container, GameObject, Rectangle, Text } from '..';
+import { Container, GameObject, Rectangle, Sprite, Text } from '..';
 import { createGameObject, setProps } from '.';
 
 jest.mock('phaser', () => {
@@ -10,6 +10,7 @@ jest.mock('phaser', () => {
     add = jest.fn();
   }
   class Rectangle extends GameObject {}
+  class Sprite extends GameObject {}
   class Text extends GameObject {}
 
   return {
@@ -18,6 +19,7 @@ jest.mock('phaser', () => {
       GameObject,
       Particles: {},
       Rectangle,
+      Sprite,
       Text,
     },
 
@@ -57,6 +59,12 @@ describe('invalid element', () => {
 
 it.each([Rectangle, Text])('creates game object from %p', (Component) => {
   expect(createGameObject(<Component />, scene)).toBeInstanceOf(GameObject);
+});
+
+it('creates game object from Sprite', () => {
+  expect(createGameObject(<Sprite texture="key" />, scene)).toBeInstanceOf(
+    GameObject,
+  );
 });
 
 it('creates game object from component', () => {

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -51,6 +51,16 @@ export function createGameObject(element: JSX.Element, scene: Phaser.Scene) {
       );
       break;
 
+    case element.type === Phaser.GameObjects.Sprite:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        props.texture,
+        props.frame,
+      );
+      break;
+
     case gameObjects.indexOf(element.type) > -1:
       gameObject = new element.type(scene);
       break;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): update Sprite props texture and frame

## What is the current behavior?

Sprite props `texture` and `frame` are not instantiated correctly:

```tsx
<Sprite texture="key" frame="key" />
```

## What is the new behavior?

Sprite props `texture` and `frame` are instantiated correctly.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation