### PR TITLE
fix(gameobject): don't override Sprite props texture and frame

### DIFF
--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -62,9 +62,9 @@ it.each([Rectangle, Text])('creates game object from %p', (Component) => {
 });
 
 it('creates game object from Sprite', () => {
-  expect(createGameObject(<Sprite texture="key" />, scene)).toBeInstanceOf(
-    GameObject,
-  );
+  expect(
+    createGameObject(<Sprite texture="texture" frame="frame" />, scene),
+  ).toBeInstanceOf(GameObject);
 });
 
 it('creates game object from component', () => {

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -24,11 +24,12 @@ export function createGameObject(element: JSX.Element, scene: Phaser.Scene) {
 
   const {
     children,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    key,
+    frame,
+    key, // eslint-disable-line @typescript-eslint/no-unused-vars
     ref,
     style,
     text,
+    texture,
     ...props
   } = element.props;
 
@@ -52,13 +53,7 @@ export function createGameObject(element: JSX.Element, scene: Phaser.Scene) {
       break;
 
     case element.type === Phaser.GameObjects.Sprite:
-      gameObject = new element.type(
-        scene,
-        props.x,
-        props.y,
-        props.texture,
-        props.frame,
-      );
+      gameObject = new element.type(scene, props.x, props.y, texture, frame);
       break;
 
     case gameObjects.indexOf(element.type) > -1:


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): don't override Sprite props texture and frame

## What is the current behavior?

Sprite props `texture` and `frame` are overridden after instantiation via `setProps`

## What is the new behavior?

Destructure props `texture` and `frame` so that they don't get passed to `setProps`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation