### PR TITLE
feat: don't export Container as Fragment

### DIFF
--- a/src/components/Fragment.test.tsx
+++ b/src/components/Fragment.test.tsx
@@ -1,0 +1,26 @@
+import { Fragment } from './Fragment';
+
+it('returns children', () => {
+  const props = { children: 'children' };
+  expect(Fragment(props)).toBe(props.children);
+});
+
+it('renders Fragment without children', () => {
+  const element = <Fragment />;
+  expect(element).toMatchObject({
+    props: {},
+    type: Fragment,
+  });
+});
+
+it('renders Fragment with children', () => {
+  const element = (
+    <Fragment>
+      <li>1</li>
+      <li>2</li>
+    </Fragment>
+  );
+  expect(element.type).toBe(Fragment);
+  expect(element.props.children).toHaveLength(2);
+  expect(element.props.children[0].type).toBe('li');
+});

--- a/src/components/Fragment.ts
+++ b/src/components/Fragment.ts
@@ -1,0 +1,11 @@
+import type { ReactNode } from 'react';
+
+/**
+ * Fragment groups elements without a wrapper node.
+ *
+ * @param props - Props.
+ * @returns - Children.
+ */
+export function Fragment(props: { children?: ReactNode }) {
+  return props.children;
+}

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,1 +1,2 @@
+export * from './Fragment';
 export * from './GameObjects';

--- a/src/jsx-dev-runtime/index.test.mjs
+++ b/src/jsx-dev-runtime/index.test.mjs
@@ -4,7 +4,6 @@ import { it } from 'node:test';
 
 import assert from 'assert';
 
-import { Container } from '../../cjs/components/index.js';
 import { createElement } from '../../cjs/element/create.js';
 import {
   Fragment,
@@ -14,7 +13,7 @@ import {
 } from '../../cjs/jsx-dev-runtime/index.js';
 
 it('exports Fragment', () => {
-  assert.strictEqual(Fragment, Container);
+  assert.strictEqual(typeof Fragment, 'function');
 });
 
 it('exports jsxDEV', () => {

--- a/src/jsx-dev-runtime/index.test.ts
+++ b/src/jsx-dev-runtime/index.test.ts
@@ -1,4 +1,4 @@
-import { Container, createElement } from '..';
+import { createElement } from '..';
 import { Fragment, jsx, jsxDEV, jsxs } from '.';
 
 it.each([jsx, jsxs])('exports %p', (func) => {
@@ -6,7 +6,7 @@ it.each([jsx, jsxs])('exports %p', (func) => {
 });
 
 it('exports Fragment', () => {
-  expect(Fragment).toBe(Container);
+  expect(Fragment).toBeInstanceOf(Function);
 });
 
 type Args = Parameters<typeof createElement>;

--- a/src/jsx-dev-runtime/index.ts
+++ b/src/jsx-dev-runtime/index.ts
@@ -1,6 +1,6 @@
 import { createElement } from '..';
 
-export { Container as Fragment, jsx, jsx as jsxs } from '..';
+export { Fragment, jsx, jsx as jsxs } from '..';
 
 type Args = Parameters<typeof createElement>;
 

--- a/src/jsx-runtime/index.test.mjs
+++ b/src/jsx-runtime/index.test.mjs
@@ -4,12 +4,11 @@ import { it } from 'node:test';
 
 import assert from 'assert';
 
-import { Container } from '../../cjs/components/index.js';
 import { createElement } from '../../cjs/element/create.js';
 import { Fragment, jsx, jsxs } from '../../cjs/jsx-runtime/index.js';
 
 it('exports Fragment', () => {
-  assert.strictEqual(Fragment, Container);
+  assert.strictEqual(typeof Fragment, 'function');
 });
 
 [jsx, jsxs].forEach((func) => {

--- a/src/jsx-runtime/index.test.ts
+++ b/src/jsx-runtime/index.test.ts
@@ -1,4 +1,4 @@
-import { Container, createElement } from '..';
+import { createElement } from '..';
 import { Fragment, jsx, jsxs } from '.';
 
 it.each([jsx, jsxs])('exports %p', (func) => {
@@ -6,5 +6,5 @@ it.each([jsx, jsxs])('exports %p', (func) => {
 });
 
 it('exports Fragment', () => {
-  expect(Fragment).toBe(Container);
+  expect(Fragment).toBeInstanceOf(Function);
 });

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -1,1 +1,1 @@
-export { Container as Fragment, jsx, jsx as jsxs } from '..';
+export { Fragment, jsx, jsx as jsxs } from '..';

--- a/src/render/render.ts
+++ b/src/render/render.ts
@@ -2,7 +2,7 @@ import Phaser from 'phaser';
 import type { JSX } from 'react';
 
 import { setScene } from '../helpers';
-import { createGameObject } from './gameobject';
+import { addGameObject } from './gameobject';
 
 /**
  * Renders a piece of JSX into a Phaser scene.
@@ -12,10 +12,5 @@ import { createGameObject } from './gameobject';
  */
 export function render(element: JSX.Element, scene: Phaser.Scene) {
   setScene(scene);
-
-  const gameObject = createGameObject(element, scene);
-
-  if (gameObject) {
-    scene.add.existing(gameObject);
-  }
+  addGameObject(element, scene);
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: don't export `Container` as `Fragment`

## What is the current behavior?

JSX `Fragment` is an alias of `Phaser.GameObjects.Container`. This causes issues when managing game objects in a list (e.g., set depth).

## What is the new behavior?

`Fragment` is now a pure function and `Container` is no longer rendered as a substitute.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation