### PR TITLE
fix(render): handle array of elements

### DIFF
--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -80,6 +80,26 @@ describe('Fragment', () => {
     expect(Phaser.GameObjects.Text).toHaveBeenCalledTimes(1);
     expect(Phaser.GameObjects.Container).toHaveBeenCalledTimes(1);
   });
+
+  it('adds array of children', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    addGameObject(
+      <Fragment>
+        <Container />
+        {Array(1)
+          .fill(null)
+          .map((_, index) => (
+            <Text text={String(index)} />
+          ))}
+      </Fragment>,
+      scene,
+    );
+    expect(Phaser.GameObjects.Container).toHaveBeenCalledTimes(1);
+    expect(Phaser.GameObjects.Text).toHaveBeenCalledTimes(1);
+    // Each child in a list should have a unique "key" prop.
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
 });
 
 describe('Container', () => {

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -20,6 +20,11 @@ export function addGameObject(
   scene: Phaser.Scene,
   container?: Phaser.GameObjects.Container,
 ) {
+  if (Array.isArray(element)) {
+    element.forEach((current) => addGameObject(current, scene, container));
+    return;
+  }
+
   if (!isValidElement(element)) {
     return;
   }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): handle array of elements

## What is the current behavior?

Array of elements are not rendered:

```tsx
<>
  <Text />
  {Array(2).fill(null).map(() => <Text />)}
</>
```

## What is the new behavior?

Array of elements are rendered

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation