### PR TITLE
fix(gameobject): fix BitmapText and DynamicBitmapText props

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -30,7 +30,10 @@ export const Arc = GameObjects.Arc as unknown as FC<Props<GameObjects.Arc>>;
  * For most use cases it is recommended to use XML. If you wish to use JSON, the formatting should be equal to the result of converting a valid XML file through the popular X2JS library. An online tool for conversion can be found here: http://codebeautify.org/xmltojson
  */
 export const BitmapText = GameObjects.BitmapText as unknown as FC<
-  Props<GameObjects.BitmapText>
+  Props<GameObjects.BitmapText> & {
+    size?: number;
+    align?: number;
+  }
 >;
 
 /**
@@ -172,7 +175,10 @@ export const DisplayList = GameObjects.DisplayList as unknown as FC<
  * For most use cases it is recommended to use XML. If you wish to use JSON, the formatting should be equal to the result of converting a valid XML file through the popular X2JS library. An online tool for conversion can be found here: http://codebeautify.org/xmltojson
  */
 export const DynamicBitmapText = GameObjects.DynamicBitmapText as unknown as FC<
-  Props<GameObjects.DynamicBitmapText>
+  Props<GameObjects.DynamicBitmapText> & {
+    size?: number;
+    align?: number;
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -1,7 +1,16 @@
 import Phaser from 'phaser';
 import type { JSX } from 'react';
 
-import { Bob, Container, Fragment, Rectangle, Sprite, Text } from '..';
+import {
+  BitmapText,
+  Bob,
+  Container,
+  DynamicBitmapText,
+  Fragment,
+  Rectangle,
+  Sprite,
+  Text,
+} from '..';
 import { addGameObject, setProps } from '.';
 
 const mockAdd = jest.fn();
@@ -9,8 +18,10 @@ const mockAdd = jest.fn();
 jest.mock('phaser', () => {
   return {
     GameObjects: {
+      BitmapText: jest.fn(),
       Bob: jest.fn(),
       Container: jest.fn(() => ({ add: mockAdd })),
+      DynamicBitmapText: jest.fn(),
       Particles: {},
       Rectangle: jest.fn(),
       Sprite: jest.fn(),
@@ -45,8 +56,10 @@ describe('invalid element', () => {
 });
 
 it.each([
+  ['BitmapText', BitmapText],
   ['Bob', Bob],
   ['Container', Container],
+  ['DynamicBitmapText', DynamicBitmapText],
   ['Rectangle', Rectangle],
   ['Sprite', Sprite],
   ['Text', Text],

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -51,6 +51,19 @@ export function addGameObject(
       }
       return;
 
+    case element.type === Phaser.GameObjects.BitmapText:
+    case element.type === Phaser.GameObjects.DynamicBitmapText:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        props.font,
+        text,
+        props.size,
+        props.align,
+      );
+      break;
+
     case element.type === Phaser.GameObjects.Container:
       gameObject = new element.type(scene, props.x, props.y);
       if (children) {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): fix BitmapText and DynamicBitmapText props

## What is the current behavior?

`BitmapText` and `DynamicBitmapText` are missing the props:
- size
- align

## What is the new behavior?

Fixed the prop types for `BitmapText` and `DynamicBitmapText`:
- size
- align

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation