### PR TITLE
fix(render): set prop text on game object

### DIFF
--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -157,7 +157,7 @@ describe('Container', () => {
 });
 
 describe('Text', () => {
-  it('adds text with no props', () => {
+  it('adds Text with no props', () => {
     addGameObject(<GameObjects.Text />, scene);
     expect(Phaser.GameObjects.Text).toHaveBeenCalledWith(
       scene,
@@ -168,7 +168,7 @@ describe('Text', () => {
     );
   });
 
-  it('adds text with props', () => {
+  it('adds Text with props', () => {
     const props = {
       x: 1,
       y: 2,
@@ -194,18 +194,66 @@ describe('Text', () => {
       children: [],
       key: null,
       ref: () => {},
-      text: 'a',
       style: {},
+      text: 'text',
     };
     const element = <GameObjects.Text {...props} />;
     addGameObject(element, scene);
-    expect(setProps).toHaveBeenCalledWith(expect.any(Object), {}, scene);
+    expect(setProps).toHaveBeenCalledWith(
+      expect.anything(),
+      { text: props.text },
+      scene,
+    );
     spy.mockRestore();
   });
 });
 
-describe('Function', () => {
-  function FunctionComponent() {
+describe('Sprite', () => {
+  it('adds Sprite', () => {
+    const props = {
+      x: 1,
+      y: 2,
+      texture: 'texture',
+      frame: 'frame',
+    };
+    const element = <GameObjects.Sprite {...props} />;
+    addGameObject(element, scene);
+    expect(Phaser.GameObjects.Sprite).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+      props.texture,
+      props.frame,
+    );
+  });
+
+  it('does not pass certain Sprite props to setProps', () => {
+    const spy = jest.spyOn(console, 'error').mockImplementation();
+    const props = {
+      children: [],
+      key: null,
+      ref: () => {},
+      x: 1,
+      y: 2,
+      texture: 'texture',
+      frame: 'frame',
+    };
+    const element = <GameObjects.Sprite {...props} />;
+    addGameObject(element, scene);
+    expect(setProps).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        x: props.x,
+        y: props.y,
+      },
+      scene,
+    );
+    spy.mockRestore();
+  });
+});
+
+describe('composite', () => {
+  function CompositeComponent() {
     return (
       <Fragment>
         <GameObjects.Text
@@ -220,11 +268,11 @@ describe('Function', () => {
     );
   }
 
-  it('renders function component', () => {
+  it('renders composite component', () => {
     function MyComponent() {
       return (
         <Fragment>
-          <FunctionComponent />
+          <CompositeComponent />
           <GameObjects.Text />
         </Fragment>
       );

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -35,7 +35,6 @@ export function addGameObject(
     key, // eslint-disable-line @typescript-eslint/no-unused-vars
     ref,
     style,
-    text,
     texture,
     ...props
   } = element.props;
@@ -78,7 +77,7 @@ export function addGameObject(
       break;
 
     case element.type === Phaser.GameObjects.Text:
-      gameObject = new element.type(scene, props.x, props.y, text, style);
+      gameObject = new element.type(scene, props.x, props.y, props.text, style);
       break;
 
     // Phaser component


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): set prop text on game object

## What is the current behavior?

Prop `text` is destructured so it's not being set on the game object (e.g., `BitmapText`)

## What is the new behavior?

Prop `text` is no longer destructured so it's set in `setProps()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation