### PR TITLE
fix(gameobject): pass props to Bob

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -57,7 +57,11 @@ export const Blitter = GameObjects.Blitter as unknown as FC<
  *
  * You can manipulate Bob objects directly from your game code, but the creation and destruction of them should be handled via the Blitter parent.
  */
-export const Bob = GameObjects.Bob as unknown as FC<Props<GameObjects.Bob>>;
+export const Bob = GameObjects.Bob as unknown as FC<
+  Props<GameObjects.Bob> & {
+    frame: string | number;
+  }
+>;
 
 /**
  * A Container Game Object.

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -141,6 +141,25 @@ describe('Fragment', () => {
   });
 });
 
+describe('Bob', () => {
+  it('instantiates game object', () => {
+    const props = {
+      x: 1,
+      y: 2,
+      frame: 'frame',
+      visible: true,
+    };
+    addGameObject(<GameObjects.Bob {...props} />, scene);
+    expect(Phaser.GameObjects.Bob).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+      props.frame,
+      props.visible,
+    );
+  });
+});
+
 describe('Container', () => {
   it('nests game objects', () => {
     function Children() {

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -55,6 +55,16 @@ export function addGameObject(
       gameObject = new element.type(scene, props.x, props.y, props.font);
       break;
 
+    case element.type === Phaser.GameObjects.Bob:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        frame,
+        props.visible,
+      );
+      break;
+
     case element.type === Phaser.GameObjects.Container:
       gameObject = new element.type(scene);
       if (children) {


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to Bob

https://docs.phaser.io/api-documentation/class/gameobjects-bob

## What is the current behavior?

`Bob` is not instantiated with required props

## What is the new behavior?

`Bob` is instantiated with required props

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation