### PR TITLE
fix(render): pass prop type to GameObject

### DIFF
--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -175,6 +175,19 @@ describe('Container', () => {
   });
 });
 
+describe('GameObject', () => {
+  it('instantiates game object', () => {
+    const props = {
+      type: 'sprite',
+    };
+    addGameObject(<GameObjects.GameObject {...props} />, scene);
+    expect(Phaser.GameObjects.GameObject).toHaveBeenCalledWith(
+      scene,
+      props.type,
+    );
+  });
+});
+
 describe('Text', () => {
   it('adds Text with no props', () => {
     addGameObject(<GameObjects.Text />, scene);

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -78,6 +78,10 @@ export function addGameObject(
       }
       break;
 
+    case element.type === Phaser.GameObjects.GameObject:
+      gameObject = new element.type(scene, props.type);
+      break;
+
     case element.type === Phaser.GameObjects.Rectangle:
       gameObject = new element.type(scene, props.x, props.y);
       break;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): pass prop type to GameObject

## What is the current behavior?

Only `scene` is instantiated in `Phaser.GameObjects.GameObject`

https://docs.phaser.io/api-documentation/class/gameobjects-gameobject

## What is the new behavior?

Passed prop `type` to `GameObject`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation