### PR TITLE
fix(gameobject): pass props texture and frame to Image

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -289,7 +289,10 @@ export const Group = GameObjects.Group as unknown as FC<
  * An Image is a light-weight Game Object useful for the display of static images in your game, such as logos, backgrounds, scenery or other non-animated elements. Images can have input events and physics bodies, or be tweened, tinted or scrolled. The main difference between an Image and a Sprite is that you cannot animate an Image as they do not have the Animation component.
  */
 export const Image = GameObjects.Image as unknown as FC<
-  Props<GameObjects.Image>
+  Props<GameObjects.Image> & {
+    texture: string | Phaser.Textures.Texture;
+    frame?: string | number;
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -240,17 +240,18 @@ describe('Text', () => {
   });
 });
 
-describe('Sprite', () => {
-  it('adds Sprite', () => {
+describe.each(['Image', 'Sprite'] as const)('%s', (component) => {
+  it('adds game object', () => {
     const props = {
       x: 1,
       y: 2,
       texture: 'texture',
       frame: 'frame',
     };
-    const element = <GameObjects.Sprite {...props} />;
+    const Component = GameObjects[component];
+    const element = <Component {...props} />;
     addGameObject(element, scene);
-    expect(Phaser.GameObjects.Sprite).toHaveBeenCalledWith(
+    expect(Phaser.GameObjects[component]).toHaveBeenCalledWith(
       scene,
       props.x,
       props.y,
@@ -259,7 +260,7 @@ describe('Sprite', () => {
     );
   });
 
-  it('does not pass certain Sprite props to setProps', () => {
+  it('does not pass certain props to setProps', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation();
     const props = {
       children: [],
@@ -270,7 +271,8 @@ describe('Sprite', () => {
       texture: 'texture',
       frame: 'frame',
     };
-    const element = <GameObjects.Sprite {...props} />;
+    const Component = GameObjects[component];
+    const element = <Component {...props} />;
     addGameObject(element, scene);
     expect(setProps).toHaveBeenCalledWith(
       expect.anything(),

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -82,12 +82,13 @@ export function addGameObject(
       gameObject = new element.type(scene, props.type);
       break;
 
-    case element.type === Phaser.GameObjects.Rectangle:
-      gameObject = new element.type(scene, props.x, props.y);
-      break;
-
+    case element.type === Phaser.GameObjects.Image:
     case element.type === Phaser.GameObjects.Sprite:
       gameObject = new element.type(scene, props.x, props.y, texture, frame);
+      break;
+
+    case element.type === Phaser.GameObjects.Rectangle:
+      gameObject = new element.type(scene, props.x, props.y);
       break;
 
     case element.type === Phaser.GameObjects.Text:


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props texture and frame to Image

## What is the current behavior?

`Image` is not instantiated with `texture` and `frame`

https://docs.phaser.io/api-documentation/class/gameobjects-image

## What is the new behavior?

`Image` is instantiated with `texture` and `frame`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation