### PR TITLE
fix(render): pass container when adding game object

### DIFF
--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -120,6 +120,21 @@ describe('Fragment', () => {
     expect(Phaser.GameObjects.Container).toHaveBeenCalledTimes(1);
   });
 
+  it('adds container', () => {
+    function Composite() {
+      return <GameObjects.Container />;
+    }
+    addGameObject(
+      <GameObjects.Container>
+        <Fragment>
+          <Composite />
+        </Fragment>
+      </GameObjects.Container>,
+      scene,
+    );
+    expect(Phaser.GameObjects.Container).toHaveBeenCalledTimes(2);
+  });
+
   it('adds array of children', () => {
     const spy = jest.spyOn(console, 'error').mockImplementation();
     addGameObject(
@@ -287,7 +302,7 @@ describe.each(['Image', 'Sprite'] as const)('%s', (component) => {
 });
 
 describe('composite', () => {
-  function CompositeComponent() {
+  function Composite() {
     return (
       <Fragment>
         <GameObjects.Text
@@ -306,7 +321,7 @@ describe('composite', () => {
     function MyComponent() {
       return (
         <Fragment>
-          <CompositeComponent />
+          <Composite />
           <GameObjects.Text />
         </Fragment>
       );

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -45,7 +45,7 @@ export function addGameObject(
     case element.type === Fragment:
       if (children) {
         toArray(children).forEach((child: JSX.Element) => {
-          addGameObject(child, scene);
+          addGameObject(child, scene, container);
         });
       }
       return;
@@ -102,7 +102,7 @@ export function addGameObject(
 
     // composite component (class/function)
     default:
-      addGameObject(new element.type(element.props), scene);
+      addGameObject(new element.type(element.props), scene, container);
       return;
   }
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(render): pass container when adding game object

## What is the current behavior?

`container` argument is not passed to all places where `addGameObject()` is called during render

## What is the new behavior?

`container` argument is passed to all places where `addGameObject()` is called during render

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation