### PR TITLE
fix(gameobject): pass props to Light

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -358,7 +358,17 @@ export const Layer = GameObjects.Layer as unknown as FC<
  * A Scene plugin that provides a Phaser.GameObjects.LightsManager for the Light2D pipeline.
  */
 export const Light = GameObjects.Light as unknown as FC<
-  Props<GameObjects.Light>
+  Props<GameObjects.Light> & {
+    x: GameObjects.Light['x'];
+    y: GameObjects.Light['y'];
+    radius: GameObjects.Light['radius'];
+    color: {
+      r: GameObjects.Light['color']['r'];
+      g: GameObjects.Light['color']['g'];
+      b: GameObjects.Light['color']['b'];
+    };
+    intensity: GameObjects.Light['intensity'];
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -248,6 +248,33 @@ describe('GameObject', () => {
   });
 });
 
+describe('Light', () => {
+  it('instantiates game object', () => {
+    const props = {
+      x: 1,
+      y: 2,
+      radius: 3,
+      color: {
+        r: 0,
+        g: 0.5,
+        b: 1,
+      },
+      intensity: 4,
+    };
+    addGameObject(<GameObjects.Light {...props} />, scene);
+    expect(Phaser.GameObjects.Light).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+      props.radius,
+      props.color.r,
+      props.color.g,
+      props.color.b,
+      props.intensity,
+    );
+  });
+});
+
 describe('Text', () => {
   it('adds Text with no props', () => {
     addGameObject(<GameObjects.Text />, scene);

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -30,6 +30,7 @@ export function addGameObject(
 
   const {
     children,
+    color,
     frame,
     key, // eslint-disable-line @typescript-eslint/no-unused-vars
     ref,
@@ -87,6 +88,19 @@ export function addGameObject(
     case element.type === Phaser.GameObjects.Image:
     case element.type === Phaser.GameObjects.Sprite:
       gameObject = new element.type(scene, props.x, props.y, texture, frame);
+      break;
+
+    case element.type === Phaser.GameObjects.Light:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        props.radius,
+        color?.r,
+        color?.g,
+        color?.b,
+        props.intensity,
+      );
       break;
 
     case element.type === Phaser.GameObjects.Rectangle:


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to Light

## What is the current behavior?

`Light` is not instantiated with props: https://docs.phaser.io/api-documentation/class/gameobjects-light

## What is the new behavior?

`Light` is instantiated with props

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation