### PR TITLE
fix(gameobject): pass props to NineSlice

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -516,7 +516,10 @@ export const Mesh = GameObjects.Mesh as unknown as FC<Props<GameObjects.Mesh>>;
  * area data from the atlas.
  */
 export const NineSlice = GameObjects.NineSlice as unknown as FC<
-  Props<GameObjects.NineSlice>
+  Props<GameObjects.NineSlice> & {
+    texture: string | Phaser.Textures.Texture;
+    frame?: string | number;
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -327,7 +327,7 @@ describe('Text', () => {
   });
 });
 
-describe.each(['Image', 'Sprite'] as const)('%s', (component) => {
+describe.each(['Image', 'Sprite', 'NineSlice'] as const)('%s', (component) => {
   it('adds game object', () => {
     const props = {
       x: 1,

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -87,6 +87,7 @@ export function addGameObject(
 
     case element.type === Phaser.GameObjects.Image:
     case element.type === Phaser.GameObjects.Sprite:
+    case element.type === Phaser.GameObjects.NineSlice:
       gameObject = new element.type(scene, props.x, props.y, texture, frame);
       break;
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to NineSlice

## What is the current behavior?

Props not passed to `NineSlice`: https://docs.phaser.io/api-documentation/class/gameobjects-nineslice

## What is the new behavior?

Props passed to `NineSlice`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation