### PR TITLE
fix(gameobject): pass props to PathFollower

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -540,7 +540,13 @@ export const ParticleEmitter = GameObjects.Particles
  * PathFollowers are bound to a single Path at any one time and can traverse the length of the Path, from start to finish, forwards or backwards, or from any given point on the Path to its end. They can optionally rotate to face the direction of the path, be offset from the path coordinates or rotate independently of the Path.
  */
 export const PathFollower = GameObjects.PathFollower as unknown as FC<
-  Props<GameObjects.PathFollower>
+  Props<GameObjects.PathFollower> & {
+    path: GameObjects.PathFollower['path'];
+    x: GameObjects.PathFollower['x'];
+    y: GameObjects.PathFollower['y'];
+    texture: string | Phaser.Textures.Texture;
+    frame?: string | number;
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -9,6 +9,9 @@ const mockAdd = jest.fn();
 
 jest.mock('phaser', () => {
   return {
+    Curves: {
+      Path: jest.fn(),
+    },
     GameObjects: {
       Arc: jest.fn(),
       BitmapText: jest.fn(),
@@ -271,6 +274,27 @@ describe('Light', () => {
       props.color.g,
       props.color.b,
       props.intensity,
+    );
+  });
+});
+
+describe('PathFollower', () => {
+  it('instantiates game object', () => {
+    const props = {
+      path: new Phaser.Curves.Path(1, 2),
+      x: 3,
+      y: 4,
+      texture: 'texture',
+      frame: 'frame',
+    };
+    addGameObject(<GameObjects.PathFollower {...props} />, scene);
+    expect(Phaser.GameObjects.PathFollower).toHaveBeenCalledWith(
+      scene,
+      props.path,
+      props.x,
+      props.y,
+      props.texture,
+      props.frame,
     );
   });
 });

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -104,6 +104,17 @@ export function addGameObject(
       );
       break;
 
+    case element.type === Phaser.GameObjects.PathFollower:
+      gameObject = new element.type(
+        scene,
+        props.path,
+        props.x,
+        props.y,
+        texture,
+        frame,
+      );
+      break;
+
     case element.type === Phaser.GameObjects.Rectangle:
       gameObject = new element.type(scene, props.x, props.y);
       break;


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to PathFollower

## What is the current behavior?

Props are not passed and instantiated in `PathFollower`: https://docs.phaser.io/api-documentation/class/gameobjects-pathfollower

## What is the new behavior?

Props passed and instantiated in `PathFollower`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation