### PR TITLE
fix(gameobject): pass props to Plane

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -567,7 +567,10 @@ export const PathFollower = GameObjects.PathFollower as unknown as FC<
  * The Plane origin is always 0.5 x 0.5 and cannot be changed.
  */
 export const Plane = GameObjects.Plane as unknown as FC<
-  Props<GameObjects.Plane>
+  Props<GameObjects.Plane> & {
+    texture: string | Phaser.Textures.Texture;
+    frame?: string | number;
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -299,6 +299,31 @@ describe('PathFollower', () => {
   });
 });
 
+describe('Plane', () => {
+  it('instantiates game object', () => {
+    const props = {
+      x: 1,
+      y: 2,
+      texture: 'texture',
+      frame: 'frame',
+      width: 3,
+      height: 4,
+      isTiled: true,
+    };
+    addGameObject(<GameObjects.Plane {...props} />, scene);
+    expect(Phaser.GameObjects.Plane).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+      props.texture,
+      props.frame,
+      props.width,
+      props.height,
+      props.isTiled,
+    );
+  });
+});
+
 describe('Text', () => {
   it('adds Text with no props', () => {
     addGameObject(<GameObjects.Text />, scene);

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -115,6 +115,19 @@ export function addGameObject(
       );
       break;
 
+    case element.type === Phaser.GameObjects.Plane:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        texture,
+        frame,
+        props.width,
+        props.height,
+        props.isTiled,
+      );
+      break;
+
     case element.type === Phaser.GameObjects.Rectangle:
       gameObject = new element.type(scene, props.x, props.y);
       break;
@@ -148,6 +161,6 @@ const gameObjects = Object.keys(GameObjects).map(
   (key) => GameObjects[key as keyof typeof GameObjects],
 );
 
-function toArray<T>(item: T | T[]) {
+function toArray<Type>(item: Type | Type[]) {
   return Array.isArray(item) ? item : [item];
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to Plane

## What is the current behavior?

Props not passed to `Plane`: https://docs.phaser.io/api-documentation/class/gameobjects-plane

## What is the new behavior?

Props passed to `Plane`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation