### PR TITLE
fix(gameobject): pass correct props to Rope

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -644,7 +644,13 @@ export const RenderTexture = GameObjects.RenderTexture as unknown as FC<
  *
  * A Ropes origin is always 0.5 x 0.5 and cannot be changed.
  */
-export const Rope = GameObjects.Rope as unknown as FC<Props<GameObjects.Rope>>;
+export const Rope = GameObjects.Rope as unknown as FC<
+  Props<Omit<GameObjects.Rope, 'points'>> & {
+    texture?: string;
+    frame?: string | number;
+    points?: number | GameObjects.Rope['points'];
+  }
+>;
 
 /**
  * A Shader Game Object.

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -355,6 +355,36 @@ describe('Rectangle', () => {
   });
 });
 
+describe('Rope', () => {
+  it('instantiates game object', () => {
+    const props = {
+      x: 1,
+      y: 2,
+    };
+    const texture = 'texture';
+    const frame = 'frame';
+    const points = 2;
+    addGameObject(
+      <GameObjects.Rope
+        {...props}
+        texture={texture}
+        frame={frame}
+        points={points}
+      />,
+      scene,
+    );
+    expect(Phaser.GameObjects.Rope).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+      texture,
+      frame,
+      points,
+    );
+    expect(setProps).toHaveBeenCalledWith(expect.anything(), props, scene);
+  });
+});
+
 describe('Text', () => {
   it('adds Text with no props', () => {
     addGameObject(<GameObjects.Text />, scene);

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -33,6 +33,7 @@ export function addGameObject(
     color,
     frame,
     key, // eslint-disable-line @typescript-eslint/no-unused-vars
+    points,
     ref,
     style,
     texture,
@@ -134,6 +135,17 @@ export function addGameObject(
 
     case element.type === Phaser.GameObjects.Rectangle:
       gameObject = new element.type(scene, props.x, props.y);
+      break;
+
+    case element.type === Phaser.GameObjects.Rope:
+      gameObject = new element.type(
+        scene,
+        props.x,
+        props.y,
+        texture,
+        frame,
+        points,
+      );
       break;
 
     case element.type === Phaser.GameObjects.Text:


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass correct props to Rope

## What is the current behavior?

Props not passed correctly to `Rope`: https://docs.phaser.io/api-documentation/class/gameobjects-rope

## What is the new behavior?

Updated types and pass props to `Rope`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation