### PR TITLE
fix(gameobject): pass props to Video

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -781,7 +781,10 @@ export const UpdateList = GameObjects.UpdateList as unknown as FC<
  * This Game Object is capable of handling playback of a previously loaded video from the Phaser Video Cache, or playing a video based on a given URL. Videos can be either local, or streamed.
  */
 export const Video = GameObjects.Video as unknown as FC<
-  Props<GameObjects.Video>
+  Props<GameObjects.Video> & {
+    x: GameObjects.Video['x'];
+    y: GameObjects.Video['y'];
+  }
 >;
 
 /**

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -551,3 +551,21 @@ describe('TileSprite', () => {
     expect(setProps).toHaveBeenCalledWith(expect.anything(), props, scene);
   });
 });
+
+describe('Video', () => {
+  it('adds game object', () => {
+    const props = {
+      x: 1,
+      y: 2,
+      cacheKey: 'cacheKey',
+    };
+    addGameObject(<GameObjects.Video {...props} />, scene);
+    expect(Phaser.GameObjects.Video).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+      props.cacheKey,
+    );
+    expect(setProps).toHaveBeenCalledWith(expect.anything(), props, scene);
+  });
+});

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -169,6 +169,10 @@ export function addGameObject(
       );
       break;
 
+    case element.type === Phaser.GameObjects.Video:
+      gameObject = new element.type(scene, props.x, props.y, props.cacheKey);
+      break;
+
     // Phaser component
     case gameObjects.indexOf(element.type) !== -1:
       gameObject = new element.type(scene);


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to Video

## What is the current behavior?

Props not passed to `Video`: https://docs.phaser.io/api-documentation/class/gameobjects-video

## What is the new behavior?

Props passed to `Video`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation