### PR TITLE
fix(gameobject): pass props to Zone

### DIFF
--- a/src/components/GameObjects.ts
+++ b/src/components/GameObjects.ts
@@ -794,4 +794,9 @@ export const Video = GameObjects.Video as unknown as FC<
  *
  * Its primary use is for creating Drop Zones and Input Hit Areas and it has a couple of helper methods specifically for this. It is also useful for object overlap checks, or as a base for your own non-displaying Game Objects. The default origin is 0.5, the center of the Zone, the same as with Game Objects.
  */
-export const Zone = GameObjects.Zone as unknown as FC<Props<GameObjects.Zone>>;
+export const Zone = GameObjects.Zone as unknown as FC<
+  Props<GameObjects.Zone> & {
+    x: GameObjects.Zone['x'];
+    y: GameObjects.Zone['y'];
+  }
+>;

--- a/src/render/gameobject.test.tsx
+++ b/src/render/gameobject.test.tsx
@@ -569,3 +569,19 @@ describe('Video', () => {
     expect(setProps).toHaveBeenCalledWith(expect.anything(), props, scene);
   });
 });
+
+describe('Zone', () => {
+  it('adds game object', () => {
+    const props = {
+      x: 1,
+      y: 2,
+    };
+    addGameObject(<GameObjects.Zone {...props} />, scene);
+    expect(Phaser.GameObjects.Zone).toHaveBeenCalledWith(
+      scene,
+      props.x,
+      props.y,
+    );
+    expect(setProps).toHaveBeenCalledWith(expect.anything(), props, scene);
+  });
+});

--- a/src/render/gameobject.ts
+++ b/src/render/gameobject.ts
@@ -135,6 +135,7 @@ export function addGameObject(
       break;
 
     case element.type === Phaser.GameObjects.Rectangle:
+    case element.type === Phaser.GameObjects.Zone:
       gameObject = new element.type(scene, props.x, props.y);
       break;
 


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(gameobject): pass props to Zone

## What is the current behavior?

Required props not passed to `Zone`: https://docs.phaser.io/api-documentation/class/gameobjects-zone

## What is the new behavior?

Required props passed to `Zone`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation