### PR TITLE
fix(types): fix prop ref

### DIFF
--- a/src/hooks/useRef.ts
+++ b/src/hooks/useRef.ts
@@ -6,7 +6,7 @@ import type { RefObject } from 'react';
  * @param initialValue - The value you want the ref object’s current property to be initially. It can be a value of any type. This argument is ignored after the initial render.
  * @returns - Returns an object with a single property `current` (initially set to the `initialValue` you have passed).
  */
-export function useRef<Type = null>(
+export function useRef<Type>(
   initialValue: Type | null = null,
 ): RefObject<Type | null> {
   return {

--- a/src/render/render.test.tsx
+++ b/src/render/render.test.tsx
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
 import type { JSX } from 'react';
 
-import { Container, createElement } from '..';
+import { Container, createElement, createRef, useRef } from '..';
 import { setScene } from '../helpers';
 import { render } from './render';
 
@@ -25,7 +25,7 @@ jest.mock('../helpers/scene', () => ({
   setScene: jest.fn(),
 }));
 
-it('does not render element into the scene', () => {
+it('does not render invalid element to the scene', () => {
   const spy = jest.spyOn(console, 'warn').mockImplementation();
   const element = {} as JSX.Element;
   const scene = new Phaser.Scene();
@@ -35,10 +35,21 @@ it('does not render element into the scene', () => {
   spy.mockRestore();
 });
 
-it('renders element into the scene', () => {
+it('renders element to the scene', () => {
   const element = createElement(Container);
   const scene = new Phaser.Scene();
   expect(render(element, scene)).toBe(undefined);
   expect(scene.add.existing).toHaveBeenCalledTimes(1);
   expect(setScene).toHaveBeenCalledWith(scene);
+});
+
+describe.each([createRef, useRef])('%p', (refFunction) => {
+  it('renders element with ref to the scene', () => {
+    const scene = new Phaser.Scene();
+    const ref = refFunction<Phaser.GameObjects.Container>();
+    expect(render(<Container ref={ref} />, scene)).toBe(undefined);
+    expect(scene.add.existing).toHaveBeenCalledTimes(1);
+    expect(setScene).toHaveBeenCalledWith(scene);
+    expect(ref).toEqual({ current: expect.any(Container) });
+  });
 });

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -6,7 +6,7 @@ type RefCallback<Type> = (gameObject: Type) => void;
 
 interface ObjectProps<Type> extends Partial<Events> {
   children?: JSX.Element | JSX.Element[] | null;
-  ref?: RefCallback<Type> | RefObject<Type>;
+  ref?: RefCallback<Type> | RefObject<Type | null>;
 }
 
 export type GameObjectProps<Type = GameObject> = ObjectProps<Type> &


### PR DESCRIPTION
## What is the motivation for this pull request?

fix(types): fix prop ref

## What is the current behavior?

TypeScript error:

```
Type 'RefObject<Container | null>' is not assignable to type 'RefCallback<Container> | RefObject<Container> | undefined'. Type 'RefObject<Container | null>' is not assignable to type 'RefObject<Container>'. Type 'Container | null' is not assignable to type 'Container'. Type 'null' is not assignable to type 'Container'.
```

## What is the new behavior?

No type errors for prop `ref`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation