### PR TITLE
fix(package): add react as optional peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,10 +44,14 @@
       },
       "peerDependencies": {
         "@types/react": "17 || 18 || 19",
-        "phaser": "3"
+        "phaser": "3",
+        "react": "17 || 18 || 19"
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        },
+        "react": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "jsx",
     "react",
     "ui",
+    "view",
+    "library",
     "game"
   ],
   "devDependencies": {
@@ -72,10 +74,14 @@
   },
   "peerDependencies": {
     "@types/react": "17 || 18 || 19",
-    "phaser": "3"
+    "phaser": "3",
+    "react": "17 || 18 || 19"
   },
   "peerDependenciesMeta": {
     "@types/react": {
+      "optional": true
+    },
+    "react": {
       "optional": true
     }
   },


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Bug fix - resolves TypeScript type resolution errors for consumers without React installed.

## What is the current behavior?

`phaser-jsx` imports JSX types from `react`, but `react` is only a devDependency. This causes ESLint errors (`@typescript-eslint/no-unsafe-return` and `@typescript-eslint/no-unsafe-argument`) and TypeScript errors for consumers who don't have React installed.

## What is the new behavior?

Added `react` as an optional peer dependency alongside `@types/react`, making it clear that React is optional while still providing types for consumers who have it installed. This resolves the type resolution errors while maintaining backward compatibility.

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->