### PR TITLE
feat(events): add gameObject as 2nd argument to pointer events

### DIFF
--- a/__tests__/render/props.test.ts
+++ b/__tests__/render/props.test.ts
@@ -1,4 +1,5 @@
 import Phaser from 'phaser';
+import type { Mock } from 'vitest';
 
 import { setProps, skipPropKeys } from '../../src/render/props';
 
@@ -106,8 +107,23 @@ describe('input', () => {
     expect(gameObject.on).toHaveBeenCalledTimes(1);
     expect(gameObject.on).toHaveBeenCalledWith(
       'pointerdown',
-      props.onPointerDown,
+      expect.any(Function),
       scene,
+    );
+
+    // Verify wrapped handler passes gameObject as 2nd argument
+    const wrappedHandler = (gameObject.on as Mock).mock.calls[0][1];
+    const pointer = {} as Phaser.Input.Pointer;
+    const localX = 10;
+    const localY = 20;
+    const event = { stopPropagation: vi.fn() };
+    wrappedHandler(pointer, localX, localY, event);
+    expect(props.onPointerDown).toHaveBeenCalledWith(
+      pointer,
+      gameObject,
+      localX,
+      localY,
+      event,
     );
   });
 
@@ -127,9 +143,40 @@ describe('input', () => {
     expect(gameObject.on).toHaveBeenCalledTimes(1);
     expect(gameObject.on).toHaveBeenCalledWith(
       'pointerover',
-      props.onPointerOver,
+      expect.any(Function),
       scene,
     );
+
+    // Verify wrapped handler passes gameObject as 2nd argument
+    const wrappedHandler = (gameObject.on as Mock).mock.calls[0][1];
+    const pointer = {} as Phaser.Input.Pointer;
+    const localX = 10;
+    const localY = 20;
+    const event = { stopPropagation: vi.fn() };
+    wrappedHandler(pointer, localX, localY, event);
+    expect(props.onPointerOver).toHaveBeenCalledWith(
+      pointer,
+      gameObject,
+      localX,
+      localY,
+      event,
+    );
+  });
+
+  it('sets non-pointer event without wrapping handler', () => {
+    const gameObject = new Phaser.GameObjects.Container(scene);
+    const props = {
+      onUpdate: vi.fn(),
+    };
+
+    gameObject.setInteractive = vi.fn();
+    gameObject.on = vi.fn();
+    expect(setProps(gameObject, props, scene)).toBe(undefined);
+
+    expect(gameObject.setInteractive).toHaveBeenCalledTimes(1);
+    expect(gameObject.setInteractive).toHaveBeenCalledWith(undefined);
+    expect(gameObject.on).toHaveBeenCalledTimes(1);
+    expect(gameObject.on).toHaveBeenCalledWith('update', props.onUpdate, scene);
   });
 });
 

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -31,7 +31,25 @@ export function setProps(
 
     if (events[key] && typeof value === 'function') {
       gameObject.setInteractive(props.input);
-      gameObject.on(key.slice(2).toLowerCase(), value, scene);
+      const eventName = key.slice(2).toLowerCase();
+      const pointerEvents = [
+        'pointerdown',
+        'pointerdownoutside',
+        'pointermove',
+        'pointerout',
+        'pointerover',
+        'pointerup',
+        'pointerupoutside',
+        'pointerwheel',
+      ];
+      if (pointerEvents.includes(eventName)) {
+        const wrappedHandler = (pointer: unknown, ...rest: unknown[]) => {
+          value(pointer, gameObject, ...rest);
+        };
+        gameObject.on(eventName, wrappedHandler, scene);
+      } else {
+        gameObject.on(eventName, value, scene);
+      }
       continue;
     }
 

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -442,12 +442,14 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer is pressed down on it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    * @param localX - The x coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param localY - The y coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param event - The Phaser input event. You can call `stopPropagation()` to halt it from going any further in the event flow.
    */
   onPointerDown: (
     pointer: Pointer,
+    gameObject: GameObject,
     localX: number,
     localY: number,
     event: EventData,
@@ -459,8 +461,9 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer is pressed down outside of it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    */
-  onPointerDownOutside: (pointer: Pointer) => void;
+  onPointerDownOutside: (pointer: Pointer, gameObject: GameObject) => void;
 
   /**
    * The Pointer Move Input Event.
@@ -468,12 +471,14 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer is moved while over it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    * @param localX - The x coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param localY - The y coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param event - The Phaser input event. You can call `stopPropagation()` to halt it from going any further in the event flow.
    */
   onPointerMove: (
     pointer: Pointer,
+    gameObject: GameObject,
     localX: number,
     localY: number,
     event: EventData,
@@ -485,9 +490,14 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer moves out of it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    * @param event - The Phaser input event. You can call `stopPropagation()` to halt it from going any further in the event flow.
    */
-  onPointerOut: (pointer: Pointer, event: EventData) => void;
+  onPointerOut: (
+    pointer: Pointer,
+    gameObject: GameObject,
+    event: EventData,
+  ) => void;
 
   /**
    * The Pointer Over Input Event.
@@ -495,12 +505,14 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer moves over it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    * @param localX - The x coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param localY - The y coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param event - The Phaser input event. You can call `stopPropagation()` to halt it from going any further in the event flow.
    */
   onPointerOver: (
     pointer: Pointer,
+    gameObject: GameObject,
     localX: number,
     localY: number,
     event: EventData,
@@ -512,12 +524,14 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer is released while over it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    * @param localX - The x coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param localY - The y coordinate that the Pointer interacted with this object on, relative to the Game Object's top-left position.
    * @param event - The Phaser input event. You can call `stopPropagation()` to halt it from going any further in the event flow.
    */
   onPointerUp: (
     pointer: Pointer,
+    gameObject: GameObject,
     localX: number,
     localY: number,
     event: EventData,
@@ -529,8 +543,9 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer is released outside of it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    */
-  onPointerUpOutside: (pointer: Pointer) => void;
+  onPointerUpOutside: (pointer: Pointer, gameObject: GameObject) => void;
 
   /**
    * The Pointer Wheel Input Event.
@@ -538,6 +553,7 @@ export interface Events {
    * This event is dispatched by an interactive Game Object if a pointer has its wheel updated while over it.
    *
    * @param pointer - The Pointer responsible for triggering this event.
+   * @param gameObject - The interactive Game Object that received this event.
    * @param deltaX - The horizontal scroll amount that occurred due to the user moving a mouse wheel or similar input device.
    * @param deltaY - The vertical scroll amount that occurred due to the user moving a mouse wheel or similar input device. This value will typically be less than 0 if the user scrolls up and greater than zero if scrolling down.
    * @param deltaZ - The z-axis scroll amount that occurred due to the user moving a mouse wheel or similar input device.
@@ -545,6 +561,7 @@ export interface Events {
    */
   onPointerWheel: (
     pointer: Pointer,
+    gameObject: GameObject,
     deltaX: number,
     deltaY: number,
     deltaZ: number,


### PR DESCRIPTION
## What is the motivation for this pull request?

This is a feature update for pointer event props so their runtime arguments align with Phaser's game object event payloads.

## What is the current behavior?

Pointer event props currently do not expose the `gameObject` argument that Phaser emits for interactive object events. This means handlers cannot access the emitting game object through the prop callback even though Phaser provides it.

## What is the new behavior?

The pointer event props now pass `gameObject` as the second argument for:

- `onPointerDown`
- `onPointerDownOutside`
- `onPointerMove`
- `onPointerOut`
- `onPointerOver`
- `onPointerUp`
- `onPointerUpOutside`
- `onPointerWheel`

The runtime prop mapping was updated, the event type definitions were expanded to include `gameObject`, and tests were added to cover the new callback arguments.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
