### PR TITLE
fix(render): support React fragment symbols

### DIFF
--- a/__tests__/element/valid.test.ts
+++ b/__tests__/element/valid.test.ts
@@ -28,6 +28,7 @@ it.each([
   { type: false },
   { type: 0 },
   { type: 'invalid' },
+  { type: Symbol('test') },
 ])('returns false for type: %s', (value) => {
   expect(isValidElement(value)).toBe(false);
 });

--- a/__tests__/render/reconcile.test.ts
+++ b/__tests__/render/reconcile.test.ts
@@ -333,6 +333,16 @@ describe('reconcileTree', () => {
     expect(result?.children).toHaveLength(2);
   });
 
+  it('handles React Fragment symbol (<>...</> shorthand)', () => {
+    const element = {
+      type: Symbol.for('react.fragment'),
+      props: { children: [createElement(Text), createElement(Text)] },
+    } as unknown as JSX.Element;
+    const result = reconcileTree(element, null, scene);
+    expect(result).toBeDefined();
+    expect(result?.children).toHaveLength(2);
+  });
+
   it('destroys extra old children when array shrinks in reconcileArray', () => {
     const child1 = { active: true, destroy: vi.fn() };
     const child2 = { active: true, destroy: vi.fn() };

--- a/examples/vite/main.tsx
+++ b/examples/vite/main.tsx
@@ -1,17 +1,21 @@
 import { Game } from 'phaser';
 
-import { Container, render, Text, useState } from '../../src';
+import { render, Text, useState } from '../../src';
 
 function Clicker() {
   const [count, setCount] = useState(0);
 
   return (
-    <Container>
+    <>
       {undefined}
       {null}
       {false}
       {0}
-      {count > 0 ? <Text text={`Clicks: ${count}`} x={16} y={16} /> : <Text text="You clicked 0 times" x={16} y={16} />}
+      {count > 0 ? (
+        <Text text={`Clicks: ${count}`} x={16} y={16} />
+      ) : (
+        <Text text="You clicked 0 times" x={16} y={16} />
+      )}
       <Text
         text="Click"
         x={16}
@@ -26,7 +30,7 @@ function Clicker() {
           setCount(count + 1);
         }}
       />
-    </Container>
+    </>
   );
 }
 

--- a/examples/vite/main.tsx
+++ b/examples/vite/main.tsx
@@ -4,6 +4,7 @@ import { render, Text, useState } from '../../src';
 
 function Clicker() {
   const [count, setCount] = useState(0);
+  const [hovered, setHovered] = useState(false);
 
   return (
     <>
@@ -21,11 +22,17 @@ function Clicker() {
         x={16}
         y={40}
         style={{
-          backgroundColor: '#fff',
+          backgroundColor: hovered ? '#87ceeb' : '#fff',
           color: '#000',
           padding: { x: 12 + count, y: 8 + count },
         }}
         input={{ cursor: 'pointer' }}
+        onPointerOver={() => {
+          setHovered(true);
+        }}
+        onPointerOut={() => {
+          setHovered(false);
+        }}
         onPointerDown={() => {
           setCount(count + 1);
         }}

--- a/src/element/valid.ts
+++ b/src/element/valid.ts
@@ -24,7 +24,7 @@ export function isValidElement(value: any) {
   if (typeof value.type !== 'function') {
     // eslint-disable-next-line no-console
     console.warn(
-      `Invalid JSX type. Expected a class or function but got: ${value.type}`,
+      `Invalid JSX type. Expected a class or function but got: ${typeof value.type === 'symbol' ? 'Symbol' : value.type}`,
     );
     return false;
   }

--- a/src/render/reconcile.ts
+++ b/src/render/reconcile.ts
@@ -42,11 +42,7 @@ export function reconcileTree(
 
     case element?.type === Fragment: {
       const children = element.props?.children;
-      const childArray = children
-        ? Array.isArray(children)
-          ? children
-          : [children]
-        : [];
+      const childArray = children ? toArray(children) : [];
       return reconcileArray(
         childArray,
         oldNode?.children ?? null,
@@ -141,11 +137,7 @@ function reconcileGameObject(
     element.type === Phaser.GameObjects.Container ||
     element.type === Phaser.GameObjects.Layer
   ) {
-    const childArray = children
-      ? Array.isArray(children)
-        ? children
-        : [children]
-      : [];
+    const childArray = children ? toArray(children) : [];
     const oldChildren = oldNode?.children ?? null;
 
     const oldLength = oldChildren?.length ?? 0;
@@ -312,4 +304,8 @@ const gameObjects = Object.keys(GameObjects).map(
 
 function isGameObject(type: unknown): boolean {
   return gameObjects.some((gameObject) => gameObject === type);
+}
+
+function toArray<Type>(item: Type | Type[]) {
+  return Array.isArray(item) ? item : [item];
 }

--- a/src/render/reconcile.ts
+++ b/src/render/reconcile.ts
@@ -25,7 +25,8 @@ export function reconcileTree(
   parent?: Phaser.GameObjects.Container | Phaser.GameObjects.Layer,
 ): GameObjectNode | null {
   switch (true) {
-    case [undefined, null].includes(element as unknown as undefined | null):
+    case element === undefined:
+    case element === null:
       if (oldNode) {
         destroyNode(oldNode);
       }
@@ -34,22 +35,22 @@ export function reconcileTree(
     case Array.isArray(element):
       return reconcileArray(element, oldNode?.children ?? null, scene, parent);
 
-    case !isValidElement(element):
-      if (oldNode) {
-        destroyNode(oldNode);
-      }
-      return null;
-
-    case element?.type === Fragment: {
+    case element?.type === Fragment:
+    case element?.type === Symbol.for('react.fragment'): {
       const children = element.props?.children;
-      const childArray = children ? toArray(children) : [];
       return reconcileArray(
-        childArray,
+        children ? toArray(children) : [],
         oldNode?.children ?? null,
         scene,
         parent,
       );
     }
+
+    case !isValidElement(element):
+      if (oldNode) {
+        destroyNode(oldNode);
+      }
+      return null;
 
     // function component
     case typeof element?.type === 'function' && !isGameObject(element.type):


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix fragment-related rendering edge cases and keep the example aligned with fragment usage and pointer interaction coverage.

## What is the current behavior?

React fragment shorthand can fail reconciliation because `Symbol.for('react.fragment')` is not handled consistently, and the example scene still uses older composition/event patterns.

## What is the new behavior?

`reconcileTree` now supports both `Fragment` and React's fragment symbol, child normalization is reused consistently, invalid element checks avoid `TypeError` on non-objects, and the Vite example uses fragments with broader pointer event coverage.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
