### PR TITLE
fix(render): treat undefined `element.type` as `Fragment`

### DIFF
--- a/__tests__/element/valid.test.ts
+++ b/__tests__/element/valid.test.ts
@@ -27,10 +27,15 @@ it.each([
   { type: null },
   { type: false },
   { type: 0 },
-  { type: 'invalid' },
   { type: Symbol('test') },
 ])('returns false for type: %s', (value) => {
   expect(isValidElement(value)).toBe(false);
+});
+
+it('returns false and warns for invalid string type', () => {
+  expect(isValidElement({ type: 'invalid' })).toBe(false);
+  // eslint-disable-next-line no-console
+  expect(console.warn).toHaveBeenCalled();
 });
 
 it('returns true for valid element', () => {

--- a/__tests__/render/render.test.tsx
+++ b/__tests__/render/render.test.tsx
@@ -82,7 +82,7 @@ function createMockScene() {
 
 it('does not render invalid element to the scene', () => {
   const spy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-  const element = {} as JSX.Element;
+  const element = { type: 'div', props: {} } as unknown as JSX.Element;
   const scene = createMockScene();
   expect(render(element, scene)).toBe(undefined);
   expect(scene.add.existing).not.toHaveBeenCalled();

--- a/src/element/valid.ts
+++ b/src/element/valid.ts
@@ -6,28 +6,31 @@
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function isValidElement(value: any) {
-  if (
-    value === null ||
-    ['undefined', 'boolean', 'number', 'string'].includes(typeof value)
-  ) {
-    return false;
-  }
+  const valueType = typeof value;
 
-  if (typeof value !== 'object') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Invalid JSX element. Expected an object but got: ${String(value)}`,
-    );
-    return false;
-  }
+  switch (true) {
+    case value === null:
+    case value === undefined:
+    case valueType === 'boolean':
+    case valueType === 'number':
+    case valueType === 'string':
+      return false;
 
-  if (typeof value.type !== 'function') {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `Invalid JSX type. Expected a class or function but got: ${typeof value.type === 'symbol' ? 'Symbol' : value.type}`,
-    );
-    return false;
-  }
+    case valueType !== 'object':
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Invalid JSX element. Expected an object but got: ${String(value)}`,
+      );
+      return false;
 
-  return true;
+    case typeof value.type !== 'function':
+      // eslint-disable-next-line no-console
+      console.warn(
+        `Invalid JSX type. Expected a class or function but got: ${typeof value.type === 'symbol' ? 'Symbol' : value.type}`,
+      );
+      return false;
+
+    default:
+      return true;
+  }
 }

--- a/src/render/reconcile.ts
+++ b/src/render/reconcile.ts
@@ -36,7 +36,9 @@ export function reconcileTree(
       return reconcileArray(element, oldNode?.children ?? null, scene, parent);
 
     case element?.type === Fragment:
-    case element?.type === Symbol.for('react.fragment'): {
+    case element?.type === Symbol.for('react.fragment'):
+    case element?.type === undefined &&
+      element?.props?.children !== undefined: {
       const children = element.props?.children;
       return reconcileArray(
         children ? toArray(children) : [],


### PR DESCRIPTION
## What is the motivation for this pull request?

This is a bug fix for fragment rendering plus a small cleanup in element validation.

## What is the current behavior?

When a consuming project uses fragments with an incompatible JSX transform configuration, `element.type` can be `undefined` and the renderer drops the fragment children.

## What is the new behavior?

The renderer now treats `element.type === undefined` with defined children as a fragment and reconciles its children instead of dropping them.

`isValidElement` is rewritten as a `switch`-based validator with the same warning behavior for invalid values, and the tests now cover invalid string types explicitly.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
