### PR TITLE
fix(render): support empty fragments

### DIFF
--- a/__tests__/render/reconcile.test.ts
+++ b/__tests__/render/reconcile.test.ts
@@ -680,6 +680,21 @@ describe('reconcileTree', () => {
     expect(result?.children).toHaveLength(0);
   });
 
+  it('handles element with undefined type and no children', () => {
+    const element = { type: undefined, props: {} } as unknown as JSX.Element;
+    const result = reconcileTree(element, null, scene);
+    expect(result?.children).toHaveLength(0);
+  });
+
+  it('handles element with undefined type and children', () => {
+    const element = {
+      type: undefined,
+      props: { children: [createElement(Text)] },
+    } as unknown as JSX.Element;
+    const result = reconcileTree(element, null, scene);
+    expect(result?.children).toHaveLength(1);
+  });
+
   it('handles Fragment with single non-array child', () => {
     const element = {
       type: Fragment,

--- a/__tests__/render/render.test.tsx
+++ b/__tests__/render/render.test.tsx
@@ -1,7 +1,13 @@
 import Phaser from 'phaser';
 import type { JSX } from 'react';
 
-import { Container, createElement, createRef, useRef } from '../../src';
+import {
+  Container,
+  createElement,
+  createRef,
+  Fragment,
+  useRef,
+} from '../../src';
 import { setScene } from '../../src/helpers';
 import { render } from '../../src/render/render';
 
@@ -122,4 +128,38 @@ it('rerenders function component with updated props', () => {
   const scene = createMockScene();
   expect(render(<Comp count={0} />, scene)).toBe(undefined);
   expect(scene.add.existing).toHaveBeenCalledTimes(1);
+});
+
+it('renders <></> shorthand with children', () => {
+  const scene = createMockScene();
+  expect(
+    render(
+      <>
+        <Container />
+        <Container />
+      </>,
+      scene,
+    ),
+  ).toBe(undefined);
+  expect(scene.add.existing).toHaveBeenCalledTimes(2);
+});
+
+it('renders <Fragment> with children', () => {
+  const scene = createMockScene();
+  expect(
+    render(
+      <Fragment>
+        <Container />
+        <Container />
+      </Fragment>,
+      scene,
+    ),
+  ).toBe(undefined);
+  expect(scene.add.existing).toHaveBeenCalledTimes(2);
+});
+
+it('renders empty <></> shorthand', () => {
+  const scene = createMockScene();
+  expect(render(<></>, scene)).toBe(undefined);
+  expect(scene.add.existing).not.toHaveBeenCalled();
 });

--- a/src/render/reconcile.ts
+++ b/src/render/reconcile.ts
@@ -37,8 +37,7 @@ export function reconcileTree(
 
     case element?.type === Fragment:
     case element?.type === Symbol.for('react.fragment'):
-    case element?.type === undefined &&
-      element?.props?.children !== undefined: {
+    case element?.type === undefined && element?.props !== undefined: {
       const children = element.props?.children;
       return reconcileArray(
         children ? toArray(children) : [],


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix for fragment reconciliation when JSX produces an element with `type === undefined`, including empty shorthand fragments.

## What is the current behavior?

Empty fragment-like elements with defined `props` but no `children` are not treated as fragments during reconciliation.

## What is the new behavior?

Reconciliation now treats elements with `type === undefined` and defined `props` as fragments, so empty fragments and fragment children render without errors. Added tests for empty and populated fragment cases in both `reconcileTree` and `render`.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation