### PR TITLE
fix(render): remove support for implicit Fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,20 @@ If you need nesting and relative positioning, use `Container`:
 </Container>
 ```
 
+Use `Fragment` to render children without a parent:
+
+```tsx
+import { Fragment } from 'phaser-jsx';
+
+<Fragment>
+  <Text text="Item 1" />
+  <Text text="Item 2" />
+</Fragment>;
+```
+
+> [!NOTE]
+> The shorthand syntax `<></>` doesn't work here.
+
 ## Hooks
 
 ### `useRef`

--- a/__tests__/render/reconcile.test.ts
+++ b/__tests__/render/reconcile.test.ts
@@ -333,16 +333,6 @@ describe('reconcileTree', () => {
     expect(result?.children).toHaveLength(2);
   });
 
-  it('handles React Fragment symbol (<>...</> shorthand)', () => {
-    const element = {
-      type: Symbol.for('react.fragment'),
-      props: { children: [createElement(Text), createElement(Text)] },
-    } as unknown as JSX.Element;
-    const result = reconcileTree(element, null, scene);
-    expect(result).toBeDefined();
-    expect(result?.children).toHaveLength(2);
-  });
-
   it('destroys extra old children when array shrinks in reconcileArray', () => {
     const child1 = { active: true, destroy: vi.fn() };
     const child2 = { active: true, destroy: vi.fn() };
@@ -678,21 +668,6 @@ describe('reconcileTree', () => {
     const element = { type: Fragment, props: {} } as unknown as JSX.Element;
     const result = reconcileTree(element, null, scene);
     expect(result?.children).toHaveLength(0);
-  });
-
-  it('handles element with undefined type and no children', () => {
-    const element = { type: undefined, props: {} } as unknown as JSX.Element;
-    const result = reconcileTree(element, null, scene);
-    expect(result?.children).toHaveLength(0);
-  });
-
-  it('handles element with undefined type and children', () => {
-    const element = {
-      type: undefined,
-      props: { children: [createElement(Text)] },
-    } as unknown as JSX.Element;
-    const result = reconcileTree(element, null, scene);
-    expect(result?.children).toHaveLength(1);
   });
 
   it('handles Fragment with single non-array child', () => {

--- a/__tests__/render/render.test.tsx
+++ b/__tests__/render/render.test.tsx
@@ -130,20 +130,6 @@ it('rerenders function component with updated props', () => {
   expect(scene.add.existing).toHaveBeenCalledTimes(1);
 });
 
-it('renders <></> shorthand with children', () => {
-  const scene = createMockScene();
-  expect(
-    render(
-      <>
-        <Container />
-        <Container />
-      </>,
-      scene,
-    ),
-  ).toBe(undefined);
-  expect(scene.add.existing).toHaveBeenCalledTimes(2);
-});
-
 it('renders <Fragment> with children', () => {
   const scene = createMockScene();
   expect(
@@ -156,10 +142,4 @@ it('renders <Fragment> with children', () => {
     ),
   ).toBe(undefined);
   expect(scene.add.existing).toHaveBeenCalledTimes(2);
-});
-
-it('renders empty <></> shorthand', () => {
-  const scene = createMockScene();
-  expect(render(<></>, scene)).toBe(undefined);
-  expect(scene.add.existing).not.toHaveBeenCalled();
 });

--- a/src/render/reconcile.ts
+++ b/src/render/reconcile.ts
@@ -35,9 +35,7 @@ export function reconcileTree(
     case Array.isArray(element):
       return reconcileArray(element, oldNode?.children ?? null, scene, parent);
 
-    case element?.type === Fragment:
-    case element?.type === Symbol.for('react.fragment'):
-    case element?.type === undefined && element?.props !== undefined: {
+    case element?.type === Fragment: {
       const children = element.props?.children;
       return reconcileArray(
         children ? toArray(children) : [],


### PR DESCRIPTION
## What is the motivation for this pull request?

This is a bug fix and API clarification for fragment rendering. The renderer should only support the exported `Fragment` API instead of implicit fragment forms.

## What is the current behavior?

The renderer accepts implicit fragment forms, including the React fragment symbol and elements with an undefined `type`, and tests cover those cases.

## What is the new behavior?

The renderer only treats the exported `Fragment` component as a fragment. Implicit fragment support and its tests are removed, and the README now documents explicit `Fragment` usage and notes that the shorthand `<></>` syntax is unsupported.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation
