### PR TITLE
fix(useEffect): prevent infinite loop when state is set

### DIFF
--- a/__tests__/helpers/context.test.ts
+++ b/__tests__/helpers/context.test.ts
@@ -1,6 +1,9 @@
 import { Scene } from 'phaser';
 
-import { createRenderContext } from '../../src/helpers/context';
+import {
+  createRenderContext,
+  setRenderContext,
+} from '../../src/helpers/context';
 import { reconcileTree } from '../../src/render/reconcile';
 
 vi.mock('../../src/render/reconcile', () => ({
@@ -10,6 +13,61 @@ vi.mock('../../src/render/reconcile', () => ({
 const scene = new Scene();
 
 describe('createRenderContext', () => {
+  describe('flushEffects', () => {
+    it('returns early when called while already rendering (re-entrancy guard)', () => {
+      const context = createRenderContext();
+      setRenderContext(context);
+
+      let reentrantCallCount = 0;
+      context.pendingEffects.push({
+        key: 0,
+        callback: () => {
+          reentrantCallCount++;
+          context.flushEffects();
+        },
+        deps: undefined,
+      });
+
+      context.flushEffects();
+
+      expect(reentrantCallCount).toBe(1);
+    });
+
+    it('schedules a deferred flushEffects via setTimeout when effects are queued during rendering and try block throws', () => {
+      vi.useFakeTimers();
+      const context = createRenderContext();
+      setRenderContext(context);
+
+      const deferred = vi.fn();
+      context.pendingEffects.push({
+        key: 0,
+        callback: () => {
+          context.pendingEffects.push({
+            key: 1,
+            callback: deferred,
+            deps: undefined,
+          });
+          context.flushEffects();
+          throw new Error('effect error');
+        },
+        deps: undefined,
+      });
+
+      let caughtError: unknown;
+      try {
+        context.flushEffects();
+      } catch (error) {
+        caughtError = error;
+      }
+
+      expect(caughtError).toBeInstanceOf(Error);
+      context.pendingEffects.splice(0, 1);
+      vi.runAllTimers();
+      expect(deferred).toHaveBeenCalledTimes(1);
+      vi.useRealTimers();
+    });
+  });
+
   it('resetStateIndex resets state index to 0', () => {
     const context = createRenderContext();
     context.getNextStateIndex();

--- a/src/helpers/context.ts
+++ b/src/helpers/context.ts
@@ -63,23 +63,43 @@ export function createRenderContext(
   let stateIndex = 0;
   let effectIndex = 0;
   let gameObjectTree: GameObjectNode | null = null;
+  let isRendering = false;
+  let needsEffectFlush = false;
 
   function flushEffects(): void {
-    for (const { key, callback, deps } of pendingEffects) {
-      const prev = effects.get(key);
-      const shouldRun =
-        !prev || deps === undefined || !areDepsEqual(prev.deps, deps);
+    if (isRendering) {
+      needsEffectFlush = true;
+      return;
+    }
 
-      if (shouldRun) {
-        if (typeof prev?.cleanup === 'function') {
-          prev.cleanup();
+    isRendering = true;
+    needsEffectFlush = false;
+
+    try {
+      for (const { key, callback, deps } of pendingEffects) {
+        const prev = effects.get(key);
+        const shouldRun =
+          !prev || deps === undefined || !areDepsEqual(prev.deps, deps);
+
+        if (shouldRun) {
+          if (typeof prev?.cleanup === 'function') {
+            prev.cleanup();
+          }
+          const cleanup = callback();
+          effects.set(key, { deps, cleanup });
         }
-        const cleanup = callback();
-        effects.set(key, { deps, cleanup });
+      }
+      pendingEffects.length = 0;
+      effectIndex = 0;
+    } finally {
+      isRendering = false;
+
+      // If effects were queued during effect execution, flush them
+      if (needsEffectFlush && pendingEffects.length > 0) {
+        // Use setTimeout to break the synchronous cycle
+        setTimeout(flushEffects);
       }
     }
-    pendingEffects.length = 0;
-    effectIndex = 0;
   }
 
   return {
@@ -110,7 +130,8 @@ export function createRenderContext(
         gameObjectTree = reconcileTree(element, gameObjectTree, scene);
       }
 
-      flushEffects();
+      // Defer effect flushing to prevent infinite loops
+      setTimeout(flushEffects);
     },
   };
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix to prevent `useEffect` from entering an infinite loop when state is updated during effect execution.

## What is the current behavior?

`flushEffects` can re-enter synchronously while effects are still being processed, which can cause recursive effect execution and infinite loops when an effect sets state.

## What is the new behavior?

Effect flushing is deferred and guarded against re-entrancy. If new effects are queued while effects are being processed, they are scheduled for a later flush instead of running synchronously. Coverage was added for the re-entrancy guard and deferred flush behavior.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
