### PR TITLE
fix(render): pass width, height, fillColor, fillAlpha to `Rectangle`; use setFillStyle in setProps

### DIFF
--- a/__tests__/render/props.test.ts
+++ b/__tests__/render/props.test.ts
@@ -28,12 +28,29 @@ vi.mock('phaser', () => {
   Text.prototype.setStyle = vi.fn();
   Text.prototype.setPadding = vi.fn();
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const Rectangle = vi.fn(function Rectangle(this: any) {
+    this.fillColor = undefined as number | undefined;
+    this.fillAlpha = undefined as number | undefined;
+  });
+
+  Rectangle.prototype.setFillStyle = vi.fn(function (
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    this: any,
+    fillColor?: number,
+    fillAlpha?: number,
+  ) {
+    this.fillColor = fillColor;
+    this.fillAlpha = fillAlpha;
+  });
+
   return {
     __esModule: true,
     default: {
       GameObjects: {
         Container: vi.fn(),
         GameObject: vi.fn(),
+        Rectangle,
         Sprite,
         Text,
       },
@@ -42,6 +59,7 @@ vi.mock('phaser', () => {
     GameObjects: {
       Container: vi.fn(),
       GameObject: vi.fn(),
+      Rectangle,
       Sprite,
       Text,
     },
@@ -234,5 +252,28 @@ describe('style', () => {
     };
     // Should not throw, just skip
     expect(() => setProps(gameObject, props, scene)).not.toThrow();
+  });
+});
+
+describe('fillColor', () => {
+  it('calls setFillStyle with fillColor', () => {
+    const gameObject = new Phaser.GameObjects.Rectangle(scene, 0, 0, 100, 100);
+    const props = { fillColor: 0x6495ed };
+    setProps(gameObject, props, scene);
+    expect(gameObject.setFillStyle).toHaveBeenCalledWith(0x6495ed, undefined);
+  });
+
+  it('calls setFillStyle with fillColor and fillAlpha', () => {
+    const gameObject = new Phaser.GameObjects.Rectangle(scene, 0, 0, 100, 100);
+    const props = { fillColor: 0xff0000, fillAlpha: 0.5 };
+    setProps(gameObject, props, scene);
+    expect(gameObject.setFillStyle).toHaveBeenCalledWith(0xff0000, 0.5);
+  });
+
+  it('calls setFillStyle with fillAlpha only', () => {
+    const gameObject = new Phaser.GameObjects.Rectangle(scene, 0, 0, 100, 100);
+    const props = { fillAlpha: 0.8 };
+    setProps(gameObject, props, scene);
+    expect(gameObject.setFillStyle).toHaveBeenCalledWith(undefined, 0.8);
   });
 });

--- a/examples/vite/main.tsx
+++ b/examples/vite/main.tsx
@@ -2,6 +2,7 @@ import { Game } from 'phaser';
 
 import {
   Fragment,
+  Rectangle,
   render,
   Text,
   useEffect,
@@ -23,15 +24,18 @@ function Clicker() {
       {null}
       {false}
       {0}
+
       {count > 0 ? (
         <Text text={`Clicks: ${count}`} x={16} y={16} />
       ) : (
         <Text text="You clicked 0 times" x={16} y={16} />
       )}
+
       <Text
         text="Click"
         x={16}
         y={40}
+        depth={1}
         style={{
           backgroundColor: hovered ? '#87ceeb' : '#fff',
           color: '#000',
@@ -47,6 +51,16 @@ function Clicker() {
         onPointerDown={() => {
           setCount(count + 1);
         }}
+      />
+
+      <Rectangle
+        x={16}
+        y={80}
+        width={120}
+        height={60}
+        fillColor={0x6495ed}
+        originX={0}
+        originY={0}
       />
     </Fragment>
   );

--- a/src/render/props.ts
+++ b/src/render/props.ts
@@ -56,6 +56,20 @@ export function setProps(
     if (key === 'style' && value && typeof value === 'object') {
       setStyle(gameObject, value);
       continue;
+    } else if (
+      (key === 'fillColor' || key === 'fillAlpha') &&
+      typeof (gameObject as Phaser.GameObjects.Rectangle).setFillStyle ===
+        'function'
+    ) {
+      const rect = gameObject as Phaser.GameObjects.Rectangle;
+      const fillColor =
+        key === 'fillColor' ? (value as number) : (props.fillColor as number);
+      const fillAlpha =
+        key === 'fillAlpha'
+          ? (value as number)
+          : (props.fillAlpha as number | undefined);
+      rect.setFillStyle(fillColor, fillAlpha);
+      continue;
     } else if (key in gameObject) {
       (gameObject as unknown as Props)[key] = value;
       continue;

--- a/src/render/reconcile.ts
+++ b/src/render/reconcile.ts
@@ -232,6 +232,16 @@ function createGameObject(
       return new element.type(scene, props?.x, props?.y, color);
 
     case element.type === Phaser.GameObjects.Rectangle:
+      return new element.type(
+        scene,
+        props?.x,
+        props?.y,
+        props?.width,
+        props?.height,
+        props?.fillColor,
+        props?.fillAlpha,
+      );
+
     case element.type === Phaser.GameObjects.Zone:
       return new element.type(scene, props?.x, props?.y);
 


### PR DESCRIPTION
## What is the motivation for this pull request?

Bug fix — `Rectangle` game objects were not rendering with their fill color.

## What is the current behavior?

`fillColor` and `fillAlpha` props were silently ignored. The `Rectangle` constructor was only passed `x` and `y`, and direct property assignment of `fillColor`/`fillAlpha` is a no-op on `Phaser.GameObjects.Rectangle`.

## What is the new behavior?

- `Rectangle` constructor now receives `width`, `height`, `fillColor`, and `fillAlpha` args.
- `fillColor` and `fillAlpha` props are applied via `setFillStyle()` in `setProps`.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation