### PR TITLE
ci(test): add page test for examples/vite in workflow test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,3 +30,10 @@ jobs:
         uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Page test
+        uses: remarkablemark/page-test-action@v1
+        with:
+          url: http://localhost:5173
+          start: npm install --prefix examples/vite && npm start --prefix examples/vite
+          wait-on: http://localhost:5173


### PR DESCRIPTION
## What is the motivation for this pull request?

Add a page test to the CI workflow that starts and tests the Vite example app.

## What is the current behavior?

The `test.yml` workflow does not test the `examples/vite` app.

## What is the new behavior?

A "Page test" step is added that installs dependencies in `examples/vite`, starts the dev server via `npm start`, and verifies the page loads at `http://localhost:5173`.

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] [Types](https://arethetypeswrong.github.io/)
- [ ] Documentation